### PR TITLE
🐞 bug : 특정경우 알람등록시 new 탭바뱃지가 확인해도 삭제안되는 문제

### DIFF
--- a/Inception/Inception/Screens/AlarmList/AlarmListViewController.swift
+++ b/Inception/Inception/Screens/AlarmList/AlarmListViewController.swift
@@ -33,11 +33,6 @@ final class AlarmListViewController: UIViewController, Storyboarded {
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    if let tabItems = tabBarController?.tabBar.items {
-        let tabItem = tabItems[1]
-        tabItem.badgeValue = nil
-    }
-    
     reloadTables(completion: configureCellForTable)
     settingClearButton()
     presentTableEmptyView.isHidden = true
@@ -48,6 +43,12 @@ final class AlarmListViewController: UIViewController, Storyboarded {
   }
   
   override func viewDidAppear(_ animated: Bool) {
+    
+    if let tabItems = tabBarController?.tabBar.items {
+        let tabItem = tabItems[1]
+        tabItem.badgeValue = nil
+    }
+    
     hideSavedListEmptyView {
       reloadTables(completion: settingClearButton)
     }


### PR DESCRIPTION
## 👀 관련 이슈

Closes #69 

## 👀 구현/변경 사항

특정경우 알람등록시 new 탭바뱃지가 확인해도 삭제안되는 버그 해결

💁‍♀️ 원인 및 버그 발생 상황
- viewDidAppear 에 탭바 뱃지 해제 코드가 있어서 초기에 한번 알람을 등록할때는 new 뱃지가 정상적으로 사라졌지만 그 이후에는 사라지지않았습니다.

✅ 해결
VC 라이프사이클에 맞게 viewDidLoad 쪽에 있던 코드를 viewDidAppear 쪽으로 옮겨서 해당 문제 해결완료했습니다

```swift
  override func viewDidAppear(_ animated: Bool) {
    
    if let tabItems = tabBarController?.tabBar.items {
        let tabItem = tabItems[1]
        tabItem.badgeValue = nil
    }
  }
```

## 👀 PR Point


## 👀 참고 사항

https://user-images.githubusercontent.com/63157395/182773774-fc3fa66c-fe5c-4e5d-af50-2850ff2da0fc.mp4


