### PR TITLE
✅ add : 저장된 알람 중복 체크 및 처리

### DIFF
--- a/Inception/Inception/Network/Models/AlarmItem+CoreDataProperties.swift
+++ b/Inception/Inception/Network/Models/AlarmItem+CoreDataProperties.swift
@@ -15,7 +15,7 @@ extension AlarmItem {
     @nonobjc public class func fetchRequest() -> NSFetchRequest<AlarmItem> {
         return NSFetchRequest<AlarmItem>(entityName: "AlarmItem")
     }
-  @NSManaged public var id : UUID
+  @NSManaged public var id : String?
     @NSManaged public var isOn: Bool
     @NSManaged public var bedTime: Date?
     @NSManaged public var wakeupTime: Date?

--- a/Inception/Inception/Network/Models/Inception.xcdatamodeld/Inception.xcdatamodel/contents
+++ b/Inception/Inception/Network/Models/Inception.xcdatamodeld/Inception.xcdatamodel/contents
@@ -2,7 +2,7 @@
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AlarmItem" representedClassName="AlarmItem" syncable="YES">
         <attribute name="bedTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="String"/>
         <attribute name="isOn" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="wakeupTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
     </entity>

--- a/Inception/Inception/Screens/AlarmCalculator/Cell/AwakeBasedRecommendCell.swift
+++ b/Inception/Inception/Screens/AlarmCalculator/Cell/AwakeBasedRecommendCell.swift
@@ -30,7 +30,9 @@ class AwakeBasedRecommendCell: UITableViewCell {
       title: AlarmDataManger.shared.fetchPresentAlarm() == nil ? "확인하기" : "변경하기",
       style: .default
     ) { UIAlertAction in
-      AlarmDataManger.shared.createAlarmItem(
+      let id = Date().dateTo24HTimeString(self.cellBedTime) + Date().dateTo24HTimeString(self.cellWakeupTime)
+       AlarmDataManger.shared.createAlarmItem(
+        id: id,
         bedTime: self.cellBedTime,
         wakeupTime: self.cellWakeupTime
       ) { onSuccess in }

--- a/Inception/Inception/Screens/AlarmCalculator/Cell/SleepBasedRecommendCell.swift
+++ b/Inception/Inception/Screens/AlarmCalculator/Cell/SleepBasedRecommendCell.swift
@@ -30,7 +30,9 @@ class SleepBasedRecommendCell: UITableViewCell {
     title: AlarmDataManger.shared.fetchPresentAlarm() == nil ? "확인하기" : "변경하기",
     style: .default
     ) { UIAlertAction in
+      let id = Date().dateTo24HTimeString(self.cellBedTime) + Date().dateTo24HTimeString(self.cellWakeupTime)
       AlarmDataManger.shared.createAlarmItem(
+        id : id,
         bedTime: self.cellBedTime,
         wakeupTime: self.cellWakeupTime
       ) { onSuccess in }


### PR DESCRIPTION
## 👀 관련 이슈
#75 

## 👀 구현/변경 사항
추가를 눌렀을 때, 중복 알람이 있는지 확인하고 
중복이라면 : 현재알람으로 설정되도록 했습니다.
AlarmDataManager의 fetchDuplicatedAlarm() 을 이용하면 중복된 알람을 가져올 수 있습니다.

fetch 

## 👀 PR Point

**요약 : id 형식 UUID -> String으로 변경**
**✴️ 테스트 시 앱 삭제 후 리빌드가 필요합니다!!!**
중복 체크에 있어 저장된 알람 목록을 돌 때
저장된 bedTimeDate, wakeupTimeDate를 둘 다 24H String으로 변경한 뒤 일일히 비교하는 방법은 비효율적이라고 판단하여
Alarm의 id 값이 기존 UUID 형식이었다면, bedTime+wakeupTime String으로 변경했습니다.
- 예시
<p align="left">
<img width="276" alt="스크린샷 2022-08-11 오후 3 42 24" src="https://user-images.githubusercontent.com/61951603/184077765-4378f6dc-6e33-4f21-bccd-8a880674b2a0.png">
-->
<img width="85" alt="스크린샷 2022-08-11 오후 3 40 02" src="https://user-images.githubusercontent.com/61951603/184077469-554af5d0-a8cd-45ad-ba32-cb306203cd6f.png">
</p>

## ⁉️ 질문
현재 중복된 알람이라서 새로 추가안됐더라도 새로운 알람이 추가될 때와 (사용자가 경험하는) 플로우는 같습니다. 괜찮을까요?

![ezgif-1-8d3a9294f8](https://user-images.githubusercontent.com/61951603/184078990-d5ceb753-c56e-47e6-927a-d669cc4bd3f9.gif)


## 👀 참고 사항

<!-- 참고할 사항(스크린샷, 실행 시 유의할 점, 참고 링크)이 있다면 적어주세요. -->