### PR TITLE
🐛 fix : '알람 찾기' 버튼 클릭 Animation 없던 문제 해결

### DIFF
--- a/Inception/Inception/Screens/AlarmCalculator/AlarmCalculatorViewController.storyboard
+++ b/Inception/Inception/Screens/AlarmCalculator/AlarmCalculatorViewController.storyboard
@@ -106,11 +106,10 @@
                                                     </constraints>
                                                     <state key="normal" title="Button"/>
                                                     <buttonConfiguration key="configuration" style="filled" title="알람 찾기">
-                                                        <backgroundConfiguration key="background" cornerRadius="8">
-                                                            <color key="backgroundColor" systemColor="systemOrangeColor"/>
-                                                        </backgroundConfiguration>
+                                                        <backgroundConfiguration key="background" cornerRadius="8"/>
                                                         <fontDescription key="titleFontDescription" type="boldSystem" pointSize="18"/>
                                                         <color key="baseForegroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <color key="baseBackgroundColor" systemColor="systemOrangeColor"/>
                                                     </buttonConfiguration>
                                                     <connections>
                                                         <action selector="searchAlarm:" destination="wts-GS-jDy" eventType="touchUpInside" id="dWS-ae-6kt"/>
@@ -224,11 +223,10 @@
                                                     </constraints>
                                                     <state key="normal" title="Button"/>
                                                     <buttonConfiguration key="configuration" style="filled" title="알람 찾기">
-                                                        <backgroundConfiguration key="background" cornerRadius="8">
-                                                            <color key="backgroundColor" systemColor="systemOrangeColor"/>
-                                                        </backgroundConfiguration>
+                                                        <backgroundConfiguration key="background" cornerRadius="8"/>
                                                         <fontDescription key="titleFontDescription" type="boldSystem" pointSize="18"/>
                                                         <color key="baseForegroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <color key="baseBackgroundColor" systemColor="systemOrangeColor"/>
                                                     </buttonConfiguration>
                                                     <connections>
                                                         <action selector="searchAlarm:" destination="Jlo-W6-gYX" eventType="touchUpInside" id="yx1-z1-JjR"/>


### PR DESCRIPTION
## 👀 관련 이슈
- #80 

## 👀 구현/변경 사항
- Button background와 Background Configuration의 Fill 의 차이였음
- Fill을 Default로 주고 Button의 background 옵션을 orange로 설정

## 👀 PR Point

## 👀 참고 사항
https://user-images.githubusercontent.com/29690062/184251889-b34392c9-d3cc-45fc-b284-7eacfaffcd47.mp4


