### PR TITLE
🐛 fix : 알람 찾기에서 알람이 추가가 안되는 현상 

### DIFF
--- a/Inception/Inception/Screens/OnBoarding/OnBoardingPageViewController.swift
+++ b/Inception/Inception/Screens/OnBoarding/OnBoardingPageViewController.swift
@@ -181,10 +181,13 @@ extension OnBoardingPageViewController {
   @objc func nextDidTap(_ sender: UIButton) {
     
     if pageControl.currentPage == pages.count - 1{
+      
       let controller = TabBarController()
       controller.modalPresentationStyle = .fullScreen
       UserDefaults.standard.hasOnboarded = true
-      present(controller, animated: true, completion: nil)
+      self.view.window?.rootViewController = controller
+      self.view.window?.rootViewController?.dismiss(animated: false, completion: nil)
+      
     } else {
       pageControl.currentPage += 1
       goToNextPage()


### PR DESCRIPTION
## 👀 관련 이슈

- Closes #83 

## 👀 구현/변경 사항

- 온보딩 이후 Next 버튼을 누르면 Modal 로 메인으로 이동하도록 설정해두었는데 이로 인하여 alert이 안보여서, 해당 내용을 root vc 를 교체하고 변경하는 방안으로 수정했습니다.

## 👀 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 👀 참고 사항

https://user-images.githubusercontent.com/63157395/184475533-8f466abd-2f66-4bc6-ba6d-bdb1f0752488.mp4


